### PR TITLE
Update build scripts to deploy scimap-rewrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host=0.0.0.0",
-    "build": "tsc -b && vite build",
+    "build": "npm install --prefix scimap-rewrite && npm run build --prefix scimap-rewrite",
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "vitest"

--- a/scimap-rewrite/vite.config.ts
+++ b/scimap-rewrite/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
       '@': path.resolve(__dirname, './src'),
     },
   },
+  build: {
+    outDir: '../dist',
+    emptyOutDir: true,
+  },
   test: {
     environment: 'jsdom',
     setupFiles: ['./setupTests.ts'],


### PR DESCRIPTION
This PR updates the build configuration so that Cloudflare Pages will build and deploy the newly rewritten app (`scimap-rewrite`).

The root `package.json` build script has been updated to run `npm install` and `npm run build` inside the `scimap-rewrite` directory. In addition, the `vite.config.ts` in the `scimap-rewrite` directory has been updated to output the built artifacts to `../dist` (the root `dist` directory), with `emptyOutDir: true` enabled. This way, any hosting provider running `npm run build` at the root will automatically get the `scimap-rewrite` build output in the expected location.

---
*PR created automatically by Jules for task [2030006267842150879](https://jules.google.com/task/2030006267842150879) started by @clvcooke*